### PR TITLE
[14.0][IMP] account_mass_reconcile_as_job: do not duplicate jobs

### DIFF
--- a/account_mass_reconcile_as_job/models/mass_reconcile.py
+++ b/account_mass_reconcile_as_job/models/mass_reconcile.py
@@ -5,6 +5,7 @@ import ast
 import logging
 
 from odoo import models
+from odoo.addons.queue_job.job import identity_exact
 
 _logger = logging.getLogger(__name__)
 
@@ -25,7 +26,8 @@ class AccountMassReconcile(models.Model):
 
         if as_job and self.env.context.get("mass_reconcile_as_job", True):
             for rec in self:
-                rec.with_delay().reconcile_as_job()
+                job_options = {"identity_key": identity_exact}
+                rec.with_delay(**job_options).reconcile_as_job()
             return True
         else:
             return super().run_reconcile()


### PR DESCRIPTION
By using `identity_key` job option.

This is to address this comment done on 12.0 version: https://github.com/camptocamp/account-reconcile/commit/c4ce973b13bf036bb7b70399da45e65d827feda1#r64018052=